### PR TITLE
Added organization info screen

### DIFF
--- a/lib/screens/organization_info/organization_info_screen.dart
+++ b/lib/screens/organization_info/organization_info_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import './widgets/organization_info_body.dart';
+
+///This is the screen through the details of a particular organization would be shown
+///This can take 2 different forms according to the user
+///If user is admin, then he can see all the settings and the details
+///If the user is a member, then he can only see the details
+///Note- in the #OrganizationInfoBody, pass 1 if user is admin else pass any other number
+///
+class OrganizationInfoScreen extends StatelessWidget {
+  final String header;
+
+  OrganizationInfoScreen(this.header);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: SafeArea(
+          child: Column(
+            children: <Widget>[
+              Stack(
+                overflow: Overflow.visible,
+                alignment: AlignmentDirectional.bottomCenter,
+                children: <Widget>[
+                  Image.asset(
+                    "assets/ecell_pic.jpg", //TODO replace with a proper image
+                    fit: BoxFit.cover,
+                    width: double.infinity,
+                  ),
+                  Positioned(
+                    bottom: -60,
+                    child: CircleAvatar(
+                      radius: 80,
+                      backgroundImage: AssetImage("assets/icon_ecell.png"),
+                      //TODO replace with a proper image
+                      backgroundColor: Colors.transparent,
+                    ),
+                  ),
+                ],
+              ),
+              //This contains the background image and the logo
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Container(
+                    decoration: BoxDecoration(
+                      color: Colors.grey,
+                      borderRadius: BorderRadius.all(Radius.circular(5)),
+                    ),
+                    margin: EdgeInsets.fromLTRB(30, 80, 0, 0),
+                    padding: EdgeInsets.fromLTRB(5, 2, 5, 2),
+                    child: Text(
+                      'Position',
+                      style: TextStyle(
+                        fontSize: 30,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    margin: EdgeInsets.fromLTRB(5, 80, 0, 0),
+                    child: Icon(Icons.info_outline),
+                  ),
+                ],
+              ),
+              //This contains the position of the user and an i button
+              OrganizationInfoBody(
+                code: 1,
+              ),
+              //pass 1 for admin/ any other number for normal user
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/organization_info/widgets/general_info.dart
+++ b/lib/screens/organization_info/widgets/general_info.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import './line.dart';
+
+/// This widget creates the general information which could be viewed by anyone
+/// This contains the details part of the organization
+class GeneralInfo extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Column(
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(0, 10, 0, 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                Line(),
+                Text(
+                  "    About    ",
+                  style: TextStyle(
+                    fontSize: 20,
+                  ),
+                ),
+                Line(),
+              ],
+            ),
+          ), //This padding contains the two lines and the Text about
+          Padding(
+            padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+            child: Container(
+              padding: EdgeInsets.fromLTRB(10, 5, 0, 5),
+              color: Colors.grey[300],
+              child: Text(
+                  "This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data "
+                  "This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data "
+                  "This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data "
+                  "This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data "
+                  "This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data"
+                  "This is dummy data This is dummy data This is dummy data This is dummy data This is dummy data "),
+            ),
+          ), //This padding corresponds to the details which would be shown
+        ],
+      ),
+    );
+  } // This widget returns the general info
+}

--- a/lib/screens/organization_info/widgets/line.dart
+++ b/lib/screens/organization_info/widgets/line.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+///Simple dart file to create a line for UI purpose
+class Line extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 10.0),
+      child: Container(
+        height: 2.0,
+        width: 130.0,
+        color: Colors.black,
+      ),
+    );
+  } //this widget creates a line
+}

--- a/lib/screens/organization_info/widgets/organization_info_body.dart
+++ b/lib/screens/organization_info/widgets/organization_info_body.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import './general_info.dart';
+import './line.dart';
+import './setting_option_tile.dart';
+
+///This dart file makes up the details part of the screen
+///If the user is an admin, this file would return settings button along with the details part
+///else if the user is a general user, then this would return only the details part
+
+class OrganizationInfoBody extends StatelessWidget {
+  final int code;
+
+  OrganizationInfoBody({@required this.code});
+
+  @override
+  Widget build(BuildContext context) {
+    if (code == 1) {
+      return Container(
+        child: Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  Line(),
+                  Text(
+                    "  Manage  ",
+                    style: TextStyle(
+                      fontSize: 20,
+                    ),
+                  ),
+                  Line(),
+                ],
+              ),
+            ), //This Padding contains two lines and text MANAGE in between
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                SettingOptionTile(
+                  title: "Groups",
+                  icon: Icon(Icons.group),
+                ),
+                SettingOptionTile(
+                  title: "Progress",
+                  icon: Icon(Icons.show_chart),
+                ),
+              ],
+            ), //contains first 2 settings button
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                SettingOptionTile(
+                  title: "Invite",
+                  icon: Icon(Icons.person_add),
+                ),
+                SettingOptionTile(
+                  title: "Certificate",
+                  icon: Icon(Icons.card_membership),
+                ),
+              ],
+            ), //contains 2nd 2 settings button
+            SettingOptionTile(
+                title: "LB settings", icon: Icon(MdiIcons.trophyAward)),
+            GeneralInfo(),
+          ],
+        ),
+      );
+    } else {
+      return GeneralInfo();
+    }
+  }
+}

--- a/lib/screens/organization_info/widgets/setting_option_tile.dart
+++ b/lib/screens/organization_info/widgets/setting_option_tile.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+///This class takes in an icon and a name for the different settings button which are to be used
+///by the admin and returns a button accordingly
+class SettingOptionTile extends StatelessWidget {
+  final String title;
+  final Icon icon;
+
+  SettingOptionTile({@required this.title, @required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: <Widget>[
+        Container(
+          margin: EdgeInsets.fromLTRB(0, 20, 0, 0),
+          width: 150,
+          height: 40,
+          child: FlatButton(
+            color: Colors.grey,
+            onPressed: () {},
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                icon,
+                Text(title),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -338,6 +338,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.6"
+  material_design_icons_flutter:
+    dependency: "direct main"
+    description:
+      name: material_design_icons_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.5345"
   meta:
     dependency: transitive
     description:
@@ -421,7 +428,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -456,7 +463,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.2"
+    version: "4.0.5+1"
   pub_semver:
     dependency: transitive
     description:
@@ -625,4 +632,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.7.0 <3.0.0"
-  flutter: ">=1.16.0 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
 
 
   cupertino_icons: ^0.1.2
+  material_design_icons_flutter: ^4.0.5345
+  #provides extra icons
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION


### Fixes #51 

### Description

This PR adds to the app a screen which would show the user either the details only or details along with the special options buttons depending on whether he is a member or an admin.

**Type of Change:** (Delete irrelevant options)
- Code
- User Interface


**Code/Quality Assurance Only** (Delete irrelevant options)
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?

Tested on local device


### Checklist:

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials
- [X] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged


**Code/Quality Assurance**
- [ ] My code follows TDD clean architecture
- [X] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
![screen for member]
![Screenshot_1591294038](https://user-images.githubusercontent.com/61823356/83794964-619d9080-a6bc-11ea-9b30-1ce6d32345a4.png)
![screen for admin](https://user-images.githubusercontent.com/61823356/83794775-1d11f500-a6bc-11ea-9a1e-cc2da07e3869.png)



